### PR TITLE
docker logs shows basic documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,10 @@ RUN echo "distinct_namespaces = 1" >> /etc/apt-cacher/apt-cacher.conf
 # extend ubuntu release names (and keep adding future versions...)
 RUN echo "ubuntu_release_names = dapper, edgy, feisty, gutsy, hardy, intrepid, jaunty, karmic, lucid, maverick, natty, oneiric, precise, quantal, trusty, utopic" >> /etc/apt-cacher/apt-cacher.conf
 
-CMD cron && apt-cacher
+ADD run.sh /
+RUN chmod +x /run.sh
+
+CMD ["/run.sh"]
 
 EXPOSE 3142
 VOLUME ["/var/cache/apt-cacher"]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+IP=$(awk "/$HOSTNAME/{print \$1}" /etc/hosts)
+DISTRIBUTIONS=$(sed -n 's/^ubuntu_release_names = //p' /etc/apt-cacher/apt-cacher.conf)
+
+cat <<EOF
+   _____ _____________________ _________               .__                  
+  /  _  \\\\______   \\__    ___/ \\_   ___ \\_____    ____ |  |__   ___________ 
+ /  /_\\  \\|     ___/ |    |    /    \\  \\/\\__  \\ _/ ___\\|  |  \\_/ __ \\_  __ \\
+/    |    \\    |     |    |    \\     \\____/ __ \\\\  \\___|   Y  \\  ___/|  | \\/
+\\____|__  /____|     |____|     \\______  (____  /\\___  >___|  /\\___  >__|   
+        \\/                             \\/     \\/     \\/     \\/     \\/       
+		
+Cache enabled for the following ubuntu disto: $DISTRIBUTIONS
+
+Container IP: $IP
+
+
+Configure your clients
+======================
+
+    echo "Acquire::http::Proxy \"http://$IP:3142\";" | sudo tee /etc/apt/apt.conf.d/01proxy
+	
+	
+Configure your Containers
+=========================
+
+In your Dockerfile, add:
+    RUN echo "Acquire::http::Proxy \"http://apt-cacher:3142\";" | sudo tee /etc/apt/apt.conf.d/01proxy
+
+Then run that container with --link:
+    docker run --link apt-cacher:apt-cacher <any container>
+	
+EOF
+
+cron && apt-cacher


### PR DESCRIPTION
With those changes, when the apt-cacher container runs it prints some basic usage
documentation to the Docker logs.

You can access this doc with:
    docker logs apt-cacher

see gh-1
