### PR TITLE
use UBUNTU_RELEASE_NAMES env to specify distributions to cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ RUN echo "allowed_hosts = *" >> /etc/apt-cacher/apt-cacher.conf
 RUN echo "distinct_namespaces = 1" >> /etc/apt-cacher/apt-cacher.conf
 
 # extend ubuntu release names (and keep adding future versions...)
-RUN echo "ubuntu_release_names = dapper, edgy, feisty, gutsy, hardy, intrepid, jaunty, karmic, lucid, maverick, natty, oneiric, precise, quantal, trusty, utopic, vivid" >> /etc/apt-cacher/apt-cacher.conf
+ENV UBUNTU_RELEASE_NAMES dapper, edgy, feisty, gutsy, hardy, intrepid, jaunty, karmic, lucid, maverick, natty, oneiric, precise, quantal, trusty, utopic, vivid
 
-CMD cron && apt-cacher
-
+ADD run.sh /
+CMD ["/run.sh"]
 EXPOSE 3142
 VOLUME ["/var/cache/apt-cacher"]

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+## specify distributions to cache from environment variable UBUNTU_RELEASE_NAMES
+echo "ubuntu_release_names = $UBUNTU_RELEASE_NAMES" >> /etc/apt-cacher/apt-cacher.conf
+
+## run the services
+cron && apt-cacher


### PR DESCRIPTION
> This is a resurrection of #6, originally filed by @thomasleveil, amended/rebased by @clue

Usage:

    docker run -d -p 3142:3142 -e UBUNTU_RELEASE_NAMES="quantal, trusty" -t apt-cacher

Closes #2