### PR TITLE
Best practices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:trusty
 MAINTAINER Christian Lück <christian@lueck.tv>
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ RUN echo "distinct_namespaces = 1" >> /etc/apt-cacher/apt-cacher.conf
 # extend ubuntu release names (and keep adding future versions...)
 RUN echo "ubuntu_release_names = dapper, edgy, feisty, gutsy, hardy, intrepid, jaunty, karmic, lucid, maverick, natty, oneiric, precise, quantal, trusty, utopic, vivid" >> /etc/apt-cacher/apt-cacher.conf
 
-CMD cron && apt-cacher
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["apt-cacher"]
 
 EXPOSE 3142
 VOLUME ["/var/cache/apt-cacher"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ RUN apt-get update \
 RUN echo "allowed_hosts = *" >> /etc/apt-cacher/apt-cacher.conf
 
 # limit disk usage
-# TODO: does not work as of now. Seems to interpret as 0 bytes maximum
-# RUN echo "disk_usage_limit = 10GB" > /etc/apt-cacher/conf.d/disk.conf
+RUN echo "disk_usage_limit = 10G" > /etc/apt-cacher/conf.d/disk.conf
 
 # enable multi-distro support (debian and ubuntu alike)
 RUN echo "distinct_namespaces = 1" >> /etc/apt-cacher/apt-cacher.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM ubuntu:trusty
 MAINTAINER Christian Lück <christian@lueck.tv>
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
-	apt-cacher
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    apt-cacher \
+    && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 # allow access from everywhere
 RUN echo "allowed_hosts = *" >> /etc/apt-cacher/apt-cacher.conf

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ "$1" = 'apt-cacher' ]; then
+    cron &
+    exec apt-cacher
+else
+    exec "$@"
+fi


### PR DESCRIPTION
I've updated the Dockerfile with best practises. Most importantly the apt-cacher process now receives the SIGTERM when stopping the container which allows for a faster and clean shutdown.
